### PR TITLE
Permission to move outside border

### DIFF
--- a/src/com/wimbli/WorldBorder/BorderCheckTask.java
+++ b/src/com/wimbli/WorldBorder/BorderCheckTask.java
@@ -46,6 +46,9 @@ public class BorderCheckTask implements Runnable
 		if (border.insideBorder(loc.getX(), loc.getZ(), Config.ShapeRound()))
 			return null;
 
+		if (player.hasPermission("worldborder.ignoreborder"))
+		    return null;
+
 		Location newLoc = newLocation(player, loc, border);
 
 		if (Config.whooshEffect())
@@ -65,7 +68,7 @@ public class BorderCheckTask implements Runnable
 			player.teleport(newLoc);
 		else
 		{
-			Vehicle ride = player.getVehicle();
+			Vehicle ride = (Vehicle) player.getVehicle();
 			if (ride != null)
 			{	// vehicles need to be offset vertically and have velocity stopped
 				double vertOffset = ride.getLocation().getY() - loc.getY();

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -31,7 +31,7 @@ commands:
            /<command> debug <on/off> - turn debug mode on or off.
 permissions:
   worldborder.*:
-    description: Grants all WorldBorder permissions
+    description: Grants all WorldBorder permissions, except worldborder.ignoreborder
     children:
       worldborder.set: true
       worldborder.radius: true
@@ -96,4 +96,7 @@ permissions:
     default: op
   worldborder.whoosh:
     description: Can enable/disable "whoosh" knockback effect
+    default: op
+  worldborder.ignoreborder:
+    description: Can move outside border
     default: op


### PR DESCRIPTION
Hi,

Thanks for a cool plugin, and the update for MC 1.2! I used it before update, too, to limit where regular players can move. I made a small change to allow certain players to ignore borders, by a permission. The update prompted me to make the same hack to the 1.2 version of it.

The story for my own server is that we have adventure builds outside borders. We want to expand the borders gradually, revealing more and more of these builds. Adventure builders of course need to move outside the borders, unlike regular players. Thus, the worldborder.ignoreborder permission.

If you feel like it doesn't mess too much with your original idea, could you please add this commit (or something similar) to your codebase?

Regards,

  st_remy
