### PR TITLE
Implemented world wrapping capability

### DIFF
--- a/src/com/wimbli/WorldBorder/BorderData.java
+++ b/src/com/wimbli/WorldBorder/BorderData.java
@@ -200,14 +200,28 @@ public class BorderData
 		// square border
 		if (!round)
 		{
-			if (xLoc <= minX)
-				xLoc = minX + Config.KnockBack();
-			else if (xLoc >= maxX)
-				xLoc = maxX - Config.KnockBack();
-			if (zLoc <= minZ)
-				zLoc = minZ + Config.KnockBack();
-			else if (zLoc >= maxZ)
-				zLoc = maxZ - Config.KnockBack();
+			if (Config.isWrapping())
+			{
+				if (xLoc <= minX)
+					xLoc = maxX - Config.KnockBack();
+				else if (xLoc >= maxX)
+					xLoc = minX + Config.KnockBack();
+				if (zLoc <= minZ)
+					zLoc = maxZ - Config.KnockBack();
+				else if (zLoc >= maxZ)
+					zLoc = minZ + Config.KnockBack();
+			}
+			else
+			{
+				if (xLoc <= minX)
+					xLoc = minX + Config.KnockBack();
+				else if (xLoc >= maxX)
+					xLoc = maxX - Config.KnockBack();
+				if (zLoc <= minZ)
+					zLoc = minZ + Config.KnockBack();
+				else if (zLoc >= maxZ)
+					zLoc = maxZ - Config.KnockBack();
+			}
 		}
 
 		// round border
@@ -222,8 +236,14 @@ public class BorderData
 			double dU = Math.sqrt(dX *dX + dZ * dZ); //distance of the untransformed point from the center
 			double dT = Math.sqrt(dX *dX / radiusXSquared + dZ * dZ / radiusZSquared); //distance of the transformed point from the center
 			double f = (1 / dT - Config.KnockBack() / dU); //"correction" factor for the distances
-			xLoc = x + dX * f;
-			zLoc = z + dZ * f;
+			if (Config.isWrapping())
+			{
+				xLoc = x - dX * f;
+				zLoc = z - dZ * f;
+			} else {
+				xLoc = x + dX * f;
+				zLoc = z + dZ * f;
+			}
 		}
 
 		int ixLoc = Location.locToBlock(xLoc);

--- a/src/com/wimbli/WorldBorder/Config.java
+++ b/src/com/wimbli/WorldBorder/Config.java
@@ -29,7 +29,7 @@ public class Config
 	public static WorldTrimTask trimTask;
 	private static Set<String> bypassPlayers = Collections.synchronizedSet(new LinkedHashSet<String>());
 	private static Runtime rt = Runtime.getRuntime();
-	
+
 	// actual configuration values which can be changed
 	private static boolean shapeRound = true;
 	private static Map<String, BorderData> borders = Collections.synchronizedMap(new LinkedHashMap<String, BorderData>());
@@ -40,6 +40,7 @@ public class Config
 	private static boolean whooshEffect = false;
 	private static boolean dynmapEnable = true;
 	private static String dynmapMessage;
+	private static boolean isWrapping = false;
 
 	// for monitoring plugin efficiency
 //	public static long timeUsed = 0;
@@ -303,6 +304,9 @@ public class Config
 		LogConfig("Border-checking timed task stopped.");
 	}
 
+	public static boolean isWrapping() {
+		retirn isWrapping;
+	}
 
 	public static void StopFillTask()
 	{
@@ -382,7 +386,7 @@ public class Config
 	}
 
 
-	private static final int currentCfgVersion = 6;
+	private static final int currentCfgVersion = 7;
 
 	public static void load(WorldBorder master, boolean logIt)
 	{	// load config from file
@@ -401,6 +405,7 @@ public class Config
 		timerTicks = cfg.getInt("timer-delay-ticks", 5);
 		dynmapEnable = cfg.getBoolean("dynmap-border-enabled", true);
 		dynmapMessage = cfg.getString("dynmap-border-message", "The border of the world.");
+		isWrapping = cfg.getBoolean("wrapping-world", false);
 		LogConfig("Using " + (ShapeName()) + " border, knockback of " + knockBack + " blocks, and timer delay of " + timerTicks + ".");
 
 		StartBorderTimer();
@@ -483,6 +488,7 @@ public class Config
 		cfg.set("timer-delay-ticks", timerTicks);
 		cfg.set("dynmap-border-enabled", dynmapEnable);
 		cfg.set("dynmap-border-message", dynmapMessage);
+		cfg.set("wrapping-world", isWrapping);
 
 		cfg.set("worlds", null);
 		Iterator world = borders.entrySet().iterator();


### PR DESCRIPTION
Added the ability to "wrap" the border, causing the user to be teleported from one end of the map to the other when the border is crossed.

The functionality is controlled by a global configuration value.

The concept from this feature is taken from the WorldWrap plugin.
