### PR TITLE
add prevent-block-place option

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/BlockPlaceListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/BlockPlaceListener.java
@@ -1,0 +1,31 @@
+package com.wimbli.WorldBorder;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+public class BlockPlaceListener implements Listener {
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onBlockPlace(BlockPlaceEvent event)
+	{
+		Location loc = event.getBlockPlaced().getLocation();
+		if (loc == null) return;
+	
+		World world = loc.getWorld();
+		if (world == null) return;
+		BorderData border = Config.Border(world.getName());
+		if (border == null) return;
+		
+		if (!border.insideBorder(loc.getX(), loc.getZ(), Config.ShapeRound())) {
+			event.setCancelled(true);
+		}
+	}
+
+	public void unregister() {
+		HandlerList.unregisterAll(this);
+	}
+}

--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -54,6 +54,7 @@ public class Config
 	private static boolean denyEnderpearl = false;
 	private static int fillAutosaveFrequency = 30;
 	private static int fillMemoryTolerance = 500;
+	private static boolean preventBlockPlace = false;
 
 	// for monitoring plugin efficiency
 //	public static long timeUsed = 0;
@@ -258,6 +259,18 @@ public class Config
 		world.playEffect(loc, Effect.SMOKE, 4);
 		world.playEffect(loc, Effect.SMOKE, 4);
 		world.playEffect(loc, Effect.GHAST_SHOOT, 0);
+	}
+	
+	public static void setPreventBlockPlace(boolean enable)
+	{
+		preventBlockPlace = enable;
+		log("prevent block place " + (enable ? "enabled" : "disabled") + ".");
+		save(true);
+	}
+	
+	public static boolean preventBlockPlace()
+	{
+		return preventBlockPlace;
 	}
 
 	public static boolean getIfPlayerKill()
@@ -566,6 +579,7 @@ public class Config
 		fillAutosaveFrequency = cfg.getInt("fill-autosave-frequency", 30);
 		importBypassStringList(cfg.getStringList("bypass-list-uuids"));
 		fillMemoryTolerance = cfg.getInt("fill-memory-tolerance", 500);
+		preventBlockPlace = cfg.getBoolean("prevent-block-place");
 
 		StartBorderTimer();
 
@@ -672,6 +686,7 @@ public class Config
 		cfg.set("fill-autosave-frequency", fillAutosaveFrequency);
 		cfg.set("bypass-list-uuids", exportBypassStringList());
 		cfg.set("fill-memory-tolerance", fillMemoryTolerance);
+		cfg.set("prevent-block-place", preventBlockPlace);
 
 		cfg.set("worlds", null);
 		for(Entry<String, BorderData> stringBorderDataEntry : borders.entrySet())

--- a/src/main/java/com/wimbli/WorldBorder/WBCommand.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBCommand.java
@@ -42,6 +42,7 @@ public class WBCommand implements CommandExecutor
 		addCmd(new CmdKnockback());		// 1
 		addCmd(new CmdWrap());			// 1
 		addCmd(new CmdWhoosh());		// 1
+		addCmd(new CmdPreventPlace());	// 1
 		addCmd(new CmdGetmsg());		// 1
 		addCmd(new CmdSetmsg());		// 1
 		addCmd(new CmdWshape());		// 3

--- a/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
@@ -8,6 +8,7 @@ public class WorldBorder extends JavaPlugin
 {
 	public static volatile WorldBorder plugin = null;
 	public static volatile WBCommand wbCommand = null;
+	private BlockPlaceListener blockPlaceListener = null;
 
 	@Override
 	public void onEnable()
@@ -25,6 +26,10 @@ public class WorldBorder extends JavaPlugin
 
 		// keep an eye on teleports, to redirect them to a spot inside the border if necessary
 		getServer().getPluginManager().registerEvents(new WBListener(), this);
+		
+		if (Config.preventBlockPlace()) {
+			enableBlockPlaceListener(true);
+		}
 
 		// integrate with DynMap if it's available
 		DynMapFeatures.setup();
@@ -56,5 +61,14 @@ public class WorldBorder extends JavaPlugin
 	public BorderData GetWorldBorder(String worldName)
 	{
 		return getWorldBorder(worldName);
+	}
+
+	public void enableBlockPlaceListener(boolean enable) {
+		if (enable) {
+			getServer().getPluginManager().registerEvents(this.blockPlaceListener = new BlockPlaceListener(), this);
+		} else {
+			blockPlaceListener.unregister();
+		}
+		
 	}
 }

--- a/src/main/java/com/wimbli/WorldBorder/cmd/CmdPreventPlace.java
+++ b/src/main/java/com/wimbli/WorldBorder/cmd/CmdPreventPlace.java
@@ -1,0 +1,47 @@
+package com.wimbli.WorldBorder.cmd;
+
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+
+import com.wimbli.WorldBorder.BlockPlaceListener;
+import com.wimbli.WorldBorder.Config;
+import com.wimbli.WorldBorder.WorldBorder;
+
+public class CmdPreventPlace extends WBCmd {
+
+	public CmdPreventPlace() {
+		name = permission = "preventblockplace";
+		minParams = 0;
+		maxParams = 1;
+
+		addCmdExample(nameEmphasized() + "<on|off> - turn prevent-block-place on or off.");
+		helpText = "Default value: off. This will prevent players from placing blocks outside the world's border.";
+	}
+	
+	@Override
+	public void cmdStatus(CommandSender sender)
+	{
+		sender.sendMessage(C_HEAD + "preventblockplace is " + enabledColored(Config.preventBlockPlace()) + C_HEAD + ".");
+	}
+
+	@Override
+	public void execute(CommandSender sender, Player player, List<String> params, String worldName)
+	{
+		if (params.size() == 1) {
+			boolean previousSetting = Config.preventBlockPlace();
+			Config.setPreventBlockPlace(strAsBool(params.get(0)));
+			if (previousSetting != Config.preventBlockPlace()) {
+				WorldBorder.plugin.enableBlockPlaceListener(Config.preventBlockPlace());
+			}
+		}
+
+		if (player != null)
+		{
+			Config.log((Config.preventBlockPlace() ? "Enabled" : "Disabled") + " preventblockplace at the command of player \"" + player.getName() + "\".");
+			cmdStatus(sender);
+		}
+	}
+}


### PR DESCRIPTION
Prevents players from placing blocks outside the world border. Default
off.

This is for the PrisonPearl plugin, where if a player is imprisoned in a
chest placed far enough outside the world border it becomes impossible
to break the chest and free the player.

The BlockPlaceEvent listener is only registered if the option is
enabled.
