### PR TITLE
Proposal: Prevent mob spawning outside world border

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 
+.idea/
+*.iml

--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -55,6 +55,7 @@ public class Config
 	private static int fillAutosaveFrequency = 30;
 	private static int fillMemoryTolerance = 500;
 	private static boolean preventBlockPlace = false;
+	private static boolean preventMobSpawn = false;
 
 	// for monitoring plugin efficiency
 //	public static long timeUsed = 0;
@@ -268,9 +269,21 @@ public class Config
 		save(true);
 	}
 	
+	public static void setPreventMobSpawn(boolean enable)
+	{
+		preventMobSpawn = enable;
+		log("prevent mob spawn " + (enable ? "enabled" : "disabled") + ".");
+		save(true);
+	}
+
 	public static boolean preventBlockPlace()
 	{
 		return preventBlockPlace;
+	}
+
+	public static boolean preventMobSpawn()
+	{
+		return preventMobSpawn;
 	}
 
 	public static boolean getIfPlayerKill()
@@ -580,6 +593,7 @@ public class Config
 		importBypassStringList(cfg.getStringList("bypass-list-uuids"));
 		fillMemoryTolerance = cfg.getInt("fill-memory-tolerance", 500);
 		preventBlockPlace = cfg.getBoolean("prevent-block-place");
+		preventMobSpawn = cfg.getBoolean("prevent-mob-spawn");
 
 		StartBorderTimer();
 
@@ -687,6 +701,7 @@ public class Config
 		cfg.set("bypass-list-uuids", exportBypassStringList());
 		cfg.set("fill-memory-tolerance", fillMemoryTolerance);
 		cfg.set("prevent-block-place", preventBlockPlace);
+		cfg.set("prevent-mob-spawn", preventMobSpawn);
 
 		cfg.set("worlds", null);
 		for(Entry<String, BorderData> stringBorderDataEntry : borders.entrySet())

--- a/src/main/java/com/wimbli/WorldBorder/MobSpawnListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/MobSpawnListener.java
@@ -1,0 +1,35 @@
+package com.wimbli.WorldBorder;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+
+
+public class MobSpawnListener implements Listener
+{
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onCreatureSpawn(CreatureSpawnEvent event)
+	{
+		Location loc = event.getEntity().getLocation();
+		if (loc == null) return;
+	
+		World world = loc.getWorld();
+		if (world == null) return;
+		BorderData border = Config.Border(world.getName());
+		if (border == null) return;
+		
+		if (!border.insideBorder(loc.getX(), loc.getZ(), Config.ShapeRound())) 
+		{
+			event.setCancelled(true);
+		}
+	}
+
+	public void unregister() 
+	{
+		HandlerList.unregisterAll(this);
+	}
+}

--- a/src/main/java/com/wimbli/WorldBorder/WBCommand.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBCommand.java
@@ -47,14 +47,15 @@ public class WBCommand implements CommandExecutor
 		addCmd(new CmdWshape());		// 3
 		//-----
 		addCmd(new CmdPreventPlace());	// 1
+		addCmd(new CmdPreventSpawn());	// 1
 		addCmd(new CmdDelay());			// 1
 		addCmd(new CmdDynmap());		// 1
 		addCmd(new CmdDynmapmsg());		// 1
 		addCmd(new CmdRemount());		// 1
 		addCmd(new CmdFillautosave());	// 1
 		addCmd(new CmdPortal());		// 1
-		addCmd(new CmdDenypearl());		// 1
 		//-----
+		addCmd(new CmdDenypearl());		// 1
 		addCmd(new CmdReload());		// 1
 		addCmd(new CmdDebug());			// 1
 

--- a/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
@@ -9,6 +9,7 @@ public class WorldBorder extends JavaPlugin
 	public static volatile WorldBorder plugin = null;
 	public static volatile WBCommand wbCommand = null;
 	private BlockPlaceListener blockPlaceListener = null;
+	private MobSpawnListener mobSpawnListener = null;
 
 	@Override
 	public void onEnable()
@@ -30,6 +31,11 @@ public class WorldBorder extends JavaPlugin
 		if (Config.preventBlockPlace()) 
 		{
 			enableBlockPlaceListener(true);
+		}
+
+		if (Config.preventMobSpawn())
+		{
+			enableMobSpawnListener(true);
 		}
 
 		// integrate with DynMap if it's available
@@ -69,9 +75,20 @@ public class WorldBorder extends JavaPlugin
 		{
 			getServer().getPluginManager().registerEvents(this.blockPlaceListener = new BlockPlaceListener(), this);
 		} 
-		else 
+		else if (blockPlaceListener != null)
 		{
 			blockPlaceListener.unregister();
+		}
+	}
+
+	public void enableMobSpawnListener(boolean enable) {
+		if (enable)
+		{
+			getServer().getPluginManager().registerEvents(this.mobSpawnListener = new MobSpawnListener(), this);
+		}
+		else if (mobSpawnListener != null)
+		{
+			mobSpawnListener.unregister();
 		}
 	}
 }

--- a/src/main/java/com/wimbli/WorldBorder/cmd/CmdPreventSpawn.java
+++ b/src/main/java/com/wimbli/WorldBorder/cmd/CmdPreventSpawn.java
@@ -1,0 +1,44 @@
+package com.wimbli.WorldBorder.cmd;
+
+import com.wimbli.WorldBorder.Config;
+import com.wimbli.WorldBorder.WorldBorder;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+public class CmdPreventSpawn extends WBCmd {
+
+	public CmdPreventSpawn() {
+		name = permission = "preventmobspawn";
+		minParams = 0;
+		maxParams = 1;
+
+		addCmdExample(nameEmphasized() + "<on|off> - stop mob spawning past border.");
+		helpText = "Default value: off. When enabled, this setting will prevent mobs from naturally spawning outside the world's border.";
+	}
+	
+	@Override
+	public void cmdStatus(CommandSender sender)
+	{
+		sender.sendMessage(C_HEAD + "Prevention of mob spawning outside the border is " + enabledColored(Config.preventMobSpawn()) + C_HEAD + ".");
+	}
+
+	@Override
+	public void execute(CommandSender sender, Player player, List<String> params, String worldName)
+	{
+		if (params.size() == 1) {
+			boolean previousSetting = Config.preventMobSpawn();
+			Config.setPreventMobSpawn(strAsBool(params.get(0)));
+			if (previousSetting != Config.preventMobSpawn()) {
+				WorldBorder.plugin.enableMobSpawnListener(Config.preventMobSpawn());
+			}
+		}
+
+		if (player != null)
+		{
+			Config.log((Config.preventMobSpawn() ? "Enabled" : "Disabled") + " preventmobspawn at the command of player \"" + player.getName() + "\".");
+			cmdStatus(sender);
+		}
+	}
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -42,6 +42,7 @@ commands:
            /<command> portal <on/off> - turn portal redirection on or off.
            /<command> denypearl <on/off> - stop ender pearls thrown past the border.
            /<command> preventblockplace <on|off> - stop block placement past border.
+           /<command> preventmobspawn <on|off> - stop mob spawning past border.
            /<command> reload - re-load data from config.yml.
            /<command> debug <on/off> - turn debug mode on or off.
 permissions:
@@ -64,6 +65,7 @@ permissions:
       worldborder.list: true
       worldborder.portal: true
       worldborder.preventblockplace: true
+      worldborder.preventmobspawn: true
       worldborder.radius: true
       worldborder.reload: true
       worldborder.remount: true
@@ -121,6 +123,9 @@ permissions:
     default: op
   worldborder.preventblockplace:
     description: Can prevent placement of blocks outside the border
+    default: op
+  worldborder.preventmobspawn:
+    description: Can prevent spawning of mobs outside the border
     default: op
   worldborder.radius:
     description: Can set the radius of an existing border


### PR DESCRIPTION
A feature suggested by a player on my server; this proposed config toggle will allow WorldBorder to prevent mob spawns outside any border. Technically, it is only listening for [`CreatureSpawnEvent`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/CreatureSpawnEvent.html) which affects:

* Natural spawns
* Spawn eggs
* Forced spawns (e.g `/spawnmob zombie 10`)

## Use cases

* **Better wither skeleton grinders** - If a nether fortress is close to or intersects a world border, players would be unable to prevent mob spawns outside with half slabs or other methods. Thus, spawns outside the border would interfere with any grinders.
* **Optimization** - Mobs that spawn outside of the border are most likely inaccessible to players; thus, it would be a waste of server resources
* **Matches vanilla behavior** - 1.8's native worldborder prevents mob spawning outside the border, thus this config will allow WorldBorder to more closely match vanilla behavior

## Implementation

I have implemented this config generally by duplicating code of the `preventBlockPlace` feature; some optimizations can be made (e.g. de-duplicate [`MobSpawnListener`](https://github.com/Gamealition/WorldBorder/blob/master/src/main/java/com/wimbli/WorldBorder/MobSpawnListener.java)'s code).

Like `preventBlockPlace`, it is `false` by default (meaning mob spawns are allowed outside the border) to prevent confusion for updating users. Included is a command and permission node for toggling this feature.

### Out-of-scope changes

* I hit a NPE in `WorldBorder.java` when disabling any of the `prevent` features, if they were already disabled. I changed the code to prevent this from happening.
* I used IntelliJ to develop my changes; I added IntelliJ files to `.gitignore` for convenience of other IntelliJ contributors

## Tests performed

* Plugin compiles and runs on Spigot 1.8.3
* `/wb preventmobspawn on` and `off` work opped
* `worldborder.preventmobspawn` correctly blocks command unless granted
* `/wb preventblockplace on` and `off` work with no regressions
* When feature is on, mobs outside border are correctly blocked from spawning
* Config is correctly updated when setting is changed