### PR TITLE
V1.9 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,14 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.wimbli.WorldBorder</groupId>
+	<groupId>com.wimbli</groupId>
 	<artifactId>WorldBorder</artifactId>
-	<version>1.8.5</version>
+	<version>1.9.0</version>
 	<name>WorldBorder</name>
-	<url>https://github.com/Brettflan/WorldBorder</url>
+	<url>https://github.com/DevotedMC/WorldBorder</url>
 	<issueManagement>
 		<system>GitHub</system>
-		<url>https://github.com/Brettflan/WorldBorder/issues</url>
+		<url>https://github.com/DevotedMC/WorldBorder/issues</url>
 	</issueManagement>
 
 	<properties>
@@ -31,13 +31,13 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.8.7-R0.1-SNAPSHOT</version>
+			<version>1.9-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Bukkit API-->
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8.7-R0.1-SNAPSHOT</version>
+			<version>1.9-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Dynmap API-->
 		<dependency>
@@ -49,15 +49,21 @@
 
 	<build>
 		<defaultGoal>clean install</defaultGoal>
-		<finalName>${project.artifactId}</finalName>
+		<finalName>${project.artifactId}-${project.version}</finalName>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
+				<version>3.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wimbli</groupId>
 	<artifactId>WorldBorder</artifactId>
-	<version>1.9.0</version>
+	<version>1.9.1</version>
 	<name>WorldBorder</name>
 	<url>https://github.com/DevotedMC/WorldBorder</url>
 	<issueManagement>

--- a/src/main/java/com/wimbli/WorldBorder/WBListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBListener.java
@@ -20,7 +20,12 @@ public class WBListener implements Listener
 			return;
 
 		if (Config.Debug())
-			Config.log("Teleport cause: " + event.getCause().toString());
+			Config.log("General Teleport cause: " + event.getCause().toString());
+
+		if (PlayerTeleportEvent.TeleportCause.NETHER_PORTAL == event.getCause()) {
+			Config.log("Skipping teleport management event - covered by onPlayerPortal");
+			return;
+		}
 
 		Location newLoc = BorderCheckTask.checkPlayer(event.getPlayer(), event.getTo(), true, true);
 		if (newLoc != null)
@@ -38,13 +43,19 @@ public class WBListener implements Listener
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onPlayerPortal(PlayerPortalEvent event)
 	{
+		if (Config.Debug())
+			Config.log("Player Portal Teleport cause: " + event.getCause().toString());
+
 		// if knockback is set to 0, or portal redirection is disabled, simply return
 		if (Config.KnockBack() == 0.0 || !Config.portalRedirection())
 			return;
 
 		Location newLoc = BorderCheckTask.checkPlayer(event.getPlayer(), event.getTo(), true, false);
-		if (newLoc != null)
+		if (newLoc != null) {
 			event.setTo(newLoc);
+		}
+
+		BorderCheckTask.timedPlayerExemption(event.getPlayer(), 100l);
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
-name: WorldBorder
+name: ${project.name}
 author: Brettflan
 description: Efficient, feature-rich plugin for limiting the size of your worlds.
-version: 1.8.5
+version: ${project.version}
 main: com.wimbli.WorldBorder.WorldBorder
 softdepend:
   - dynmap


### PR DESCRIPTION
Addresses #59 and upgrades WorldBorder explicitly to 1.9's Bukkit API.

Concerning #59, basically, it's a synchronization problem. Standard player checks defaulting at 1sec intervals are capturing an "incomplete" transition -- the player world is updated, but their inventory and location are not for, potentially, several seconds. 

While by no means a total fix, I've simply leveraged the "handling player" exemption system already in place to give a grace period of a few seconds post-teleport. 

I've also added an explicit capture for NETHER_PORTAL type events in the general teleportation event listener so that both listeners aren't attempting to handle the same event. 

Feel free to use all or some or none of this code, but I have it in production on my server and it has restored nether travel. I'll report any bugs if they occur and update this pull appropriately.