### PR TITLE
V1.9 quickfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wimbli.WorldBorder</groupId>
 	<artifactId>WorldBorder</artifactId>
-	<version>1.8.7</version>
+	<version>1.8.8</version>
 	<name>WorldBorder</name>
 	<url>https://github.com/Brettflan/WorldBorder</url>
 	<issueManagement>
@@ -60,7 +60,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.5.1</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wimbli.WorldBorder</groupId>
 	<artifactId>WorldBorder</artifactId>
-	<version>1.8.5</version>
+	<version>1.8.7</version>
 	<name>WorldBorder</name>
 	<url>https://github.com/Brettflan/WorldBorder</url>
 	<issueManagement>
@@ -31,13 +31,13 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.8.7-R0.1-SNAPSHOT</version>
+			<version>1.9-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Bukkit API-->
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8.7-R0.1-SNAPSHOT</version>
+			<version>1.9-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Dynmap API-->
 		<dependency>
@@ -49,15 +49,21 @@
 
 	<build>
 		<defaultGoal>clean install</defaultGoal>
-		<finalName>${project.artifactId}</finalName>
+		<finalName>${project.artifactId}-${project.version}</finalName>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
+				<version>3.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -56,6 +56,8 @@ public class Config
 	private static int fillMemoryTolerance = 500;
 	private static boolean preventBlockPlace = false;
 	private static boolean preventMobSpawn = false;
+	private static long maxExemptionTicks = 21l;
+	private static long portalRecheckTicks = 4l; // These together give 5 recheck chances over the course of a second.
 
 	// for monitoring plugin efficiency
 //	public static long timeUsed = 0;
@@ -539,6 +541,21 @@ public class Config
 
 		return false;
 	}
+	
+	
+	public static long getMaxExemptionTicks() {
+		return maxExemptionTicks;
+	}
+	public static void setMaxExemptionTicks(long maxExemptionTicks) {
+		Config.maxExemptionTicks = maxExemptionTicks;
+	}
+	
+	public static long getPortalRecheckTicks() {
+		return portalRecheckTicks;
+	}
+	public static void setPortalRecheckTicks(long portalRecheckTicks) {
+		Config.portalRecheckTicks = portalRecheckTicks;
+	}
 
 
 	public static String replaceAmpColors (String message)
@@ -600,6 +617,8 @@ public class Config
 		fillMemoryTolerance = cfg.getInt("fill-memory-tolerance", 500);
 		preventBlockPlace = cfg.getBoolean("prevent-block-place");
 		preventMobSpawn = cfg.getBoolean("prevent-mob-spawn");
+		maxExemptionTicks = cfg.getLong("max-exemption-ticks", 21l);
+		portalRecheckTicks = cfg.getLong("portal-recheck-ticks", 4l);
 
 		StartBorderTimer();
 
@@ -708,6 +727,8 @@ public class Config
 		cfg.set("fill-memory-tolerance", fillMemoryTolerance);
 		cfg.set("prevent-block-place", preventBlockPlace);
 		cfg.set("prevent-mob-spawn", preventMobSpawn);
+		cfg.set("max-exemption-ticks", maxExemptionTicks);
+		cfg.set("portal-recheck-ticks", portalRecheckTicks);
 
 		cfg.set("worlds", null);
 		for(Entry<String, BorderData> stringBorderDataEntry : borders.entrySet())
@@ -746,4 +767,5 @@ public class Config
 		if (logIt)
 			logConfig("Configuration saved.");
 	}
+
 }

--- a/src/main/java/com/wimbli/WorldBorder/WBListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBListener.java
@@ -20,7 +20,12 @@ public class WBListener implements Listener
 			return;
 
 		if (Config.Debug())
-			Config.log("Teleport cause: " + event.getCause().toString());
+			Config.log("General Teleport cause: " + event.getCause().toString());
+
+		if (PlayerTeleportEvent.TeleportCause.NETHER_PORTAL == event.getCause()) {
+			Config.log("Skipping teleport management event - covered by onPlayerPortal");
+			return;
+		}
 
 		Location newLoc = BorderCheckTask.checkPlayer(event.getPlayer(), event.getTo(), true, true);
 		if (newLoc != null)
@@ -38,13 +43,19 @@ public class WBListener implements Listener
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onPlayerPortal(PlayerPortalEvent event)
 	{
+		if (Config.Debug())
+			Config.log("Player Portal Teleport cause: " + event.getCause().toString());
+
 		// if knockback is set to 0, or portal redirection is disabled, simply return
 		if (Config.KnockBack() == 0.0 || !Config.portalRedirection())
 			return;
 
 		Location newLoc = BorderCheckTask.checkPlayer(event.getPlayer(), event.getTo(), true, false);
-		if (newLoc != null)
+		if (newLoc != null) {
 			event.setTo(newLoc);
+		}
+
+		BorderCheckTask.timedPlayerExemption(event.getPlayer(), 100l);
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/com/wimbli/WorldBorder/WBListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBListener.java
@@ -52,7 +52,7 @@ public class WBListener implements Listener
 			event.setTo(newLoc);
 		}
 
-		BorderCheckTask.timedPlayerExemption(event.getPlayer(), event.getTo().getWorld().getName(),
+		BorderCheckTask.timedPlayerExemption(event.getPlayer(), event.getFrom().clone(),
 				Config.getMaxExemptionTicks(), Config.getPortalRecheckTicks());
 	}
 

--- a/src/main/java/com/wimbli/WorldBorder/WBListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBListener.java
@@ -9,7 +9,6 @@ import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.Location;
 
-
 public class WBListener implements Listener
 {
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
@@ -19,11 +18,9 @@ public class WBListener implements Listener
 		if (Config.KnockBack() == 0.0)
 			return;
 
-		if (Config.Debug())
-			Config.log("General Teleport cause: " + event.getCause().toString());
-
-		if (PlayerTeleportEvent.TeleportCause.NETHER_PORTAL == event.getCause()) {
-			Config.log("Skipping teleport management event - covered by onPlayerPortal");
+		if (event instanceof PlayerPortalEvent) { // Avoid overlapping management.
+			if (Config.Debug())
+				Config.log("Skipping teleport management event - covered by onPlayerPortal");
 			return;
 		}
 
@@ -55,7 +52,8 @@ public class WBListener implements Listener
 			event.setTo(newLoc);
 		}
 
-		BorderCheckTask.timedPlayerExemption(event.getPlayer(), 100l);
+		BorderCheckTask.timedPlayerExemption(event.getPlayer(), event.getTo().getWorld().getName(),
+				Config.getMaxExemptionTicks(), Config.getPortalRecheckTicks());
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
-name: WorldBorder
+name: ${project.name}
 author: Brettflan
 description: Efficient, feature-rich plugin for limiting the size of your worlds.
-version: 1.8.5
+version: ${project.version}
 main: com.wimbli.WorldBorder.WorldBorder
 softdepend:
   - dynmap


### PR DESCRIPTION
Based on our comment exchange in pull #60 I do not expect this to be merged in whole (although feel free to cherrypick the pom & plugin update commit). 

However, this addresses #59 via a work-around while we wait for Spigot to correct. Some of us, sadly, do not have the luxury of waiting for Spigot to address the issue that fixing, but also cannot safely disable WorldBorder within the Nether. Hence I'm placing this PR so that folks can build a workaround locally for their servers.

Here is a snippet of my investigation into the actual source of #59, which is not as was assumed incorrect player From within the teleportation event, but is rather an eventual consistency problem with the Player location in Bukkit. As a result, the cause of the problem becomes _WorldBorder itself_ since Spigot puts incorrect data in the Player object, causing the BorderCheckTask to "fix" the player's location during a regular update, causing the spurious second teleportation.

Again, the actual Bukkit-called events are totally fine -- To and From are 100% correct, always -- but the backing _Player_ data has inconsistent state tracking / eventual consistency problems. 

Illustration -- I run a separate plugin to help players avoid "trapped" netherportals, and I have it set up to spit out teleportation event data for debugging, currently:

Here is the original teleportation event; you can check the math, world is 8:1 standard nether, the original teleport event is correct:

```
[05:05:13] [Server thread/INFO]: [WorldBorder] Teleport cause: NETHER_PORTAL
[05:05:13] [Server thread/INFO]: [PortalFix] DeepCopy teleported from Location{world=CraftWorld{name=world},x=-8.189748678030902,y=68.24918707874468,z
=251.82862061288284,pitch=22.949966,yaw=-95.05548} to Location{world=CraftWorld{name=world_nether},x=0.0,y=70.0,z=28.0,pitch=22.949966,yaw=-95.05548}
with cause NETHER_PORTAL (cancelled? false)
```

You can also see that WorldBorder catches that event and sees no issue.

Then, a second later:

```
[05:05:14] [Server thread/WARN]: [WorldBorder] Border crossing in "world_nether". Border radius 200 at X: 1.6 Z: 27.7
[05:05:14] [Server thread/WARN]: [WorldBorder] Player position X: -8.2 Y: 68.2 Z: 251.8
[05:05:14] [Server thread/WARN]: [WorldBorder] New position in world "world_nether" at X: -7.5 Y: 68.0 Z: 224.5
[05:05:14] [Server thread/INFO]: [WorldBorder] Teleport cause: PLUGIN
[05:05:14] [Server thread/INFO]: [PortalFix] DeepCopy teleported from Location{world=CraftWorld{name=world_nether},x=-8.189748678030902,y=68.249187078
74468,z=251.82862061288284,pitch=22.949966,yaw=84.94452} to Location{world=CraftWorld{name=world_nether},x=-7.5,y=68.0,z=224.5,pitch=22.949966,yaw=84.
94452} with cause PLUGIN (cancelled? false)
```

WorldBorder now teleports the player to the _wrong_ location, during the per-second "checkPlayer" event, because of the player data inconsistency I have described.

Hope this helps. As with the prior, I'd be grateful if you left this PR open until Bukkit fixes, just so people can see a possible solution, but I do not expect it to be merged.
