### PR TITLE
Update for 1.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.wimbli.WorldBorder</groupId>
 	<artifactId>WorldBorder</artifactId>
-	<version>1.8.7</version>
+	<version>1.9.0</version>
 	<name>WorldBorder</name>
 	<url>https://github.com/Brettflan/WorldBorder</url>
 	<issueManagement>
@@ -22,7 +22,7 @@
 		</repository>
 		<repository>
 			<id>dynmap-repo</id>
-			<url>http://repo.mikeprimm.com/</url>
+			<url>https://repo.mikeprimm.com/</url>
 		</repository>
 	</repositories>
 
@@ -31,19 +31,19 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.10.2-R0.1-SNAPSHOT</version>
+			<version>1.13-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Bukkit API-->
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.10.2-R0.1-SNAPSHOT</version>
+			<version>1.13-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Dynmap API-->
 		<dependency>
-			<groupId>org.dynmap</groupId>
+			<groupId>us.dynmap</groupId>
 			<artifactId>dynmap-api</artifactId>
-			<version>2.0</version>
+			<version>2.5</version>
 		</dependency>
 	</dependencies>
 
@@ -54,10 +54,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
+				<version>3.8.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,13 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.13-R0.1-SNAPSHOT</version>
+			<version>1.13.1-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Bukkit API-->
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.13-R0.1-SNAPSHOT</version>
+			<version>1.13.1-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!--Dynmap API-->
 		<dependency>

--- a/src/main/java/com/wimbli/WorldBorder/BorderCheckTask.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderCheckTask.java
@@ -3,14 +3,13 @@ package com.wimbli.WorldBorder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -97,16 +96,25 @@ public class BorderCheckTask implements Runnable
 
 		// check if player has something (a pet, maybe?) riding them; only possible through odd plugins.
 		// it can prevent all teleportation of the player completely, so it's very much not good and needs handling
-		if (player.getPassenger() != null)
+		List<Entity> passengers = player.getPassengers();
+		if (!passengers.isEmpty())
 		{
-			Entity rider = player.getPassenger();
 			player.eject();
-			rider.teleport(newLoc, TeleportCause.PLUGIN);
-			player.sendMessage("Your passenger has been ejected.");
-			if (Config.Debug())
-				Config.logWarn("Player had a passenger riding on them: " + rider.getType());
+			for (Entity rider : passengers)
+			{
+				rider.teleport(newLoc, TeleportCause.PLUGIN);
+				if (Config.Debug())
+					Config.logWarn("Player had a passenger riding on them: " + rider.getType());
+			}
+			if (passengers.size() == 1)
+			{
+				player.sendMessage("Your passenger has been ejected.");
+			}
+			else
+			{
+				player.sendMessage("Your passengers have been ejected.");
+			}
 		}
-
 
 		// give some particle and sound effects where the player was beyond the border, if "whoosh effect" is enabled
 		Config.showWhooshEffect(loc);
@@ -170,7 +178,7 @@ public class BorderCheckTask implements Runnable
 				if (vehicle == null || player == null)
 					return;
 
-				vehicle.setPassenger(player);
+				vehicle.addPassenger(player);
 			}
 		}, delay);
 	}

--- a/src/main/java/com/wimbli/WorldBorder/BorderData.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderData.java
@@ -363,6 +363,19 @@ public class BorderData
 		safeOpenBlocks.add(Material.TRIPWIRE_HOOK);
 		safeOpenBlocks.add(Material.CARROTS);
 		safeOpenBlocks.add(Material.POTATOES);
+		safeOpenBlocks.add(Material.OAK_BUTTON);
+		safeOpenBlocks.add(Material.SPRUCE_BUTTON);
+		safeOpenBlocks.add(Material.BIRCH_BUTTON);
+		safeOpenBlocks.add(Material.JUNGLE_BUTTON);
+		safeOpenBlocks.add(Material.ACACIA_BUTTON);
+		safeOpenBlocks.add(Material.DARK_OAK_BUTTON);
+		safeOpenBlocks.add(Material.SUNFLOWER);
+		safeOpenBlocks.add(Material.LILAC);
+		safeOpenBlocks.add(Material.ROSE_BUSH);
+		safeOpenBlocks.add(Material.PEONY);
+		safeOpenBlocks.add(Material.TALL_GRASS);
+		safeOpenBlocks.add(Material.LARGE_FERN);
+		safeOpenBlocks.add(Material.BEETROOTS);
 	}
 
 	//these material IDs are ones we don't want to drop the player onto, like cactus or lava or fire or activated Ender portal

--- a/src/main/java/com/wimbli/WorldBorder/BorderData.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderData.java
@@ -1,10 +1,10 @@
 package com.wimbli.WorldBorder;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
+import java.util.EnumSet;
 
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 
 
@@ -291,26 +291,102 @@ public class BorderData
 	}
 
 	//these material IDs are acceptable for places to teleport player; breathable blocks and water
-	public static final LinkedHashSet<Integer> safeOpenBlocks = new LinkedHashSet<Integer>(Arrays.asList(
-		 new Integer[] {0, 6, 8, 9, 27, 28, 30, 31, 32, 37, 38, 39, 40, 50, 55, 59, 63, 64, 65, 66, 68, 69, 70, 71, 72, 75, 76, 77, 78, 83, 90, 93, 94, 96, 104, 105, 106, 115, 131, 132, 141, 142, 149, 150, 157, 171}
-	));
+	public static final EnumSet<Material> safeOpenBlocks = EnumSet.noneOf(Material.class);
+	static
+	{
+		safeOpenBlocks.add(Material.AIR);
+		safeOpenBlocks.add(Material.CAVE_AIR);
+		safeOpenBlocks.add(Material.OAK_SAPLING);
+		safeOpenBlocks.add(Material.SPRUCE_SAPLING);
+		safeOpenBlocks.add(Material.BIRCH_SAPLING);
+		safeOpenBlocks.add(Material.JUNGLE_SAPLING);
+		safeOpenBlocks.add(Material.ACACIA_SAPLING);
+		safeOpenBlocks.add(Material.DARK_OAK_SAPLING);
+		safeOpenBlocks.add(Material.WATER);
+		safeOpenBlocks.add(Material.RAIL);
+		safeOpenBlocks.add(Material.POWERED_RAIL);
+		safeOpenBlocks.add(Material.DETECTOR_RAIL);
+		safeOpenBlocks.add(Material.ACTIVATOR_RAIL);
+		safeOpenBlocks.add(Material.COBWEB);
+		safeOpenBlocks.add(Material.GRASS);
+		safeOpenBlocks.add(Material.FERN);
+		safeOpenBlocks.add(Material.DEAD_BUSH);
+		safeOpenBlocks.add(Material.DANDELION);
+		safeOpenBlocks.add(Material.POPPY);
+		safeOpenBlocks.add(Material.BLUE_ORCHID);
+		safeOpenBlocks.add(Material.ALLIUM);
+		safeOpenBlocks.add(Material.AZURE_BLUET);
+		safeOpenBlocks.add(Material.RED_TULIP);
+		safeOpenBlocks.add(Material.ORANGE_TULIP);
+		safeOpenBlocks.add(Material.WHITE_TULIP);
+		safeOpenBlocks.add(Material.PINK_TULIP);
+		safeOpenBlocks.add(Material.OXEYE_DAISY);
+		safeOpenBlocks.add(Material.BROWN_MUSHROOM);
+		safeOpenBlocks.add(Material.RED_MUSHROOM);
+		safeOpenBlocks.add(Material.TORCH);
+		safeOpenBlocks.add(Material.WALL_TORCH);
+		safeOpenBlocks.add(Material.REDSTONE_WIRE);
+		safeOpenBlocks.add(Material.WHEAT);
+		safeOpenBlocks.add(Material.SIGN);
+		safeOpenBlocks.add(Material.WALL_SIGN);
+		safeOpenBlocks.add(Material.LADDER);
+		safeOpenBlocks.add(Material.LEVER);
+		safeOpenBlocks.add(Material.LIGHT_WEIGHTED_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.HEAVY_WEIGHTED_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.STONE_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.OAK_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.SPRUCE_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.BIRCH_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.JUNGLE_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.ACACIA_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.DARK_OAK_PRESSURE_PLATE);
+		safeOpenBlocks.add(Material.REDSTONE_TORCH);
+		safeOpenBlocks.add(Material.REDSTONE_WALL_TORCH);
+		safeOpenBlocks.add(Material.STONE_BUTTON);
+		safeOpenBlocks.add(Material.SNOW);
+		safeOpenBlocks.add(Material.SUGAR_CANE);
+		safeOpenBlocks.add(Material.REPEATER);
+		safeOpenBlocks.add(Material.COMPARATOR);
+		safeOpenBlocks.add(Material.OAK_TRAPDOOR);
+		safeOpenBlocks.add(Material.SPRUCE_TRAPDOOR);
+		safeOpenBlocks.add(Material.BIRCH_TRAPDOOR);
+		safeOpenBlocks.add(Material.JUNGLE_TRAPDOOR);
+		safeOpenBlocks.add(Material.ACACIA_TRAPDOOR);
+		safeOpenBlocks.add(Material.DARK_OAK_TRAPDOOR);
+		safeOpenBlocks.add(Material.MELON_STEM);
+		safeOpenBlocks.add(Material.ATTACHED_MELON_STEM);
+		safeOpenBlocks.add(Material.PUMPKIN_STEM);
+		safeOpenBlocks.add(Material.ATTACHED_PUMPKIN_STEM);
+		safeOpenBlocks.add(Material.VINE);
+		safeOpenBlocks.add(Material.NETHER_WART);
+		safeOpenBlocks.add(Material.TRIPWIRE);
+		safeOpenBlocks.add(Material.TRIPWIRE_HOOK);
+		safeOpenBlocks.add(Material.CARROTS);
+		safeOpenBlocks.add(Material.POTATOES);
+	}
 
 	//these material IDs are ones we don't want to drop the player onto, like cactus or lava or fire or activated Ender portal
-	public static final LinkedHashSet<Integer> painfulBlocks = new LinkedHashSet<Integer>(Arrays.asList(
-		 new Integer[] {10, 11, 51, 81, 119}
-	));
+	public static final EnumSet<Material> painfulBlocks = EnumSet.noneOf(Material.class);
+	static
+	{
+		painfulBlocks.add(Material.LAVA);
+		painfulBlocks.add(Material.FIRE);
+		painfulBlocks.add(Material.CACTUS);
+		painfulBlocks.add(Material.END_PORTAL);
+		painfulBlocks.add(Material.MAGMA_BLOCK);
+	}
 
 	// check if a particular spot consists of 2 breathable blocks over something relatively solid
 	private boolean isSafeSpot(World world, int X, int Y, int Z, boolean flying)
 	{
-		boolean safe = safeOpenBlocks.contains((Integer)world.getBlockTypeIdAt(X, Y, Z))		// target block open and safe
-					&& safeOpenBlocks.contains((Integer)world.getBlockTypeIdAt(X, Y + 1, Z));	// above target block open and safe
+		boolean safe = safeOpenBlocks.contains(world.getBlockAt(X, Y, Z).getType())		// target block open and safe
+					&& safeOpenBlocks.contains(world.getBlockAt(X, Y + 1, Z).getType());	// above target block open and safe
 		if (!safe || flying)
 			return safe;
 
-		Integer below = (Integer)world.getBlockTypeIdAt(X, Y - 1, Z);
+		Material below = world.getBlockAt(X, Y - 1, Z).getType();
 		return (safe
-			 && (!safeOpenBlocks.contains(below) || below == 8 || below == 9)	// below target block not open/breathable (so presumably solid), or is water
+			 && (!safeOpenBlocks.contains(below) || below == Material.WATER)	// below target block not open/breathable (so presumably solid), or is water
 			 && !painfulBlocks.contains(below)									// below target block not painful
 			);
 	}

--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -435,7 +435,7 @@ public class Config
 
 	public static ArrayList<UUID> getPlayerBypassList()
 	{
-		return new ArrayList(bypassPlayers);
+		return new ArrayList<>(bypassPlayers);
 	}
 
 	// for converting bypass UUID list to/from String list, for storage in config
@@ -670,7 +670,7 @@ public class Config
 				}
 
 				Boolean overrideShape = (Boolean) bord.get("shape-round");
-				boolean wrap = (boolean) bord.getBoolean("wrapping", false);
+				boolean wrap = bord.getBoolean("wrapping", false);
 				BorderData border = new BorderData(bord.getDouble("x", 0), bord.getDouble("z", 0), bord.getInt("radiusX", 0), bord.getInt("radiusZ", 0), overrideShape, wrap);
 				borders.put(worldName, border);
 				logConfig(BorderDescription(worldName));
@@ -733,9 +733,8 @@ public class Config
 		cfg.set("worlds", null);
 		for(Entry<String, BorderData> stringBorderDataEntry : borders.entrySet())
 		{
-			Entry wdata = stringBorderDataEntry;
-			String name = ((String)wdata.getKey()).replace(".", "<");
-			BorderData bord = (BorderData)wdata.getValue();
+			String name = stringBorderDataEntry.getKey().replace(".", "<");
+			BorderData bord = stringBorderDataEntry.getValue();
 
 			cfg.set("worlds." + name + ".x", bord.getX());
 			cfg.set("worlds." + name + ".z", bord.getZ());

--- a/src/main/java/com/wimbli/WorldBorder/DynMapFeatures.java
+++ b/src/main/java/com/wimbli/WorldBorder/DynMapFeatures.java
@@ -155,9 +155,8 @@ public class DynMapFeatures
 		Map<String, BorderData> borders = Config.getBorders();
 		for(Entry<String, BorderData> stringBorderDataEntry : borders.entrySet())
 		{
-			Entry wdata = stringBorderDataEntry;
-			String worldName = ((String)wdata.getKey());
-			BorderData border = (BorderData)wdata.getValue();
+			String worldName = stringBorderDataEntry.getKey();
+			BorderData border = stringBorderDataEntry.getValue();
 			showBorder(worldName, border);
 		}
 	}

--- a/src/main/java/com/wimbli/WorldBorder/WBCommand.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBCommand.java
@@ -205,7 +205,7 @@ public class WBCommand implements CommandExecutor
 	public Set<String> getCommandNames()
 	{
 		// using TreeSet to sort alphabetically
-		Set<String> commands = new TreeSet(subCommands.keySet());
+		Set<String> commands = new TreeSet<>(subCommands.keySet());
 		// removing default "commands" command as it's not normally shown or run like other commands
 		commands.remove("commands");
 		return commands;

--- a/src/main/java/com/wimbli/WorldBorder/WBListener.java
+++ b/src/main/java/com/wimbli/WorldBorder/WBListener.java
@@ -1,6 +1,5 @@
 package com.wimbli.WorldBorder;
 
-import org.bukkit.Chunk;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;

--- a/src/main/java/com/wimbli/WorldBorder/WorldTrimTask.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldTrimTask.java
@@ -271,7 +271,7 @@ public class WorldTrimTask implements Runnable
 		for (CoordXZ unload : trimChunks)
 		{
 			if (world.isChunkLoaded(unload.x, unload.z))
-				world.unloadChunk(unload.x, unload.z, false, false);
+				world.unloadChunk(unload.x, unload.z, false);
 		}
 		counter += trimChunks.size();
 	}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,8 @@
 name: WorldBorder
 author: Brettflan
 description: Efficient, feature-rich plugin for limiting the size of your worlds.
-version: 1.8.7
+version: 1.9.0
+api-version: 1.13
 main: com.wimbli.WorldBorder.WorldBorder
 softdepend:
   - dynmap


### PR DESCRIPTION
I updated the plugin for Bukkit/Spigot 1.13.

- Materials instead of material ids
- Use the new passenger API
- Build against java 1.8 instead of 1.6
- Some minor cleanups
- Update version to 1.9.0 because this is a breaking change (will only work on Spigot 1.13+ because of the new material names)