### PR TITLE
Alter fully generated prediction to match 1.13.x worldgen behavior

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/WorldFileData.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldFileData.java
@@ -134,14 +134,15 @@ public class WorldFileData
 	// Minecraft only fully generates a chunk when adjacent chunks are also loaded.
 	public boolean isChunkFullyGenerated(int x, int z)
 	{	// if all adjacent chunks exist, it should be a safe enough bet that this one is fully generated
-		return
-			! (
-			! doesChunkExist(x, z)
-		 || ! doesChunkExist(x+1, z)
-		 || ! doesChunkExist(x-1, z)
-		 || ! doesChunkExist(x, z+1)
-		 || ! doesChunkExist(x, z-1)
-			);
+	    // For 1.13+, due to world gen changes, this is now effectively a 3 chunk radius requirement vs a 1 chunk radius
+	    for (int xx = x-3; xx <= x+3; xx++) {
+	        for (int zz = z-3; zz <= z-3; zz++) {
+	            if (!doesChunkExist(xx, zz)) {
+	                return false;
+	            }
+	        }
+	    }
+	    return true;
 	}
 
 	// Method to let us know a chunk has been generated, to update our region map.


### PR DESCRIPTION
This is a 1.13-specific fix for https://github.com/Brettflan/WorldBorder/issues/101.  The existing POM suggests the WB build is 1.13-specific, but this logic can be altered to handle 1.13+ vs pre-1.13 pretty easily if needed.

The implications of the need for the fix also imply that having run /wb fill on 1.13 without the fix will leave some previously border chunks in a 'not quite cooked' state (where they now are surrounded by 3 layers of chunks but never were driven all the way to being generated).  This can be fixed with a /wb fill with force=true. for folks where that has happened.