### PR TITLE
Don't request chunk unloads during fill

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/BorderData.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderData.java
@@ -406,8 +406,13 @@ public class BorderData
 	// check if a particular spot consists of 2 breathable blocks over something relatively solid
 	private boolean isSafeSpot(World world, int X, int Y, int Z, boolean flying)
 	{
-		boolean safe = safeOpenBlocks.contains(world.getBlockAt(X, Y, Z).getType())		// target block open and safe
-					&& safeOpenBlocks.contains(world.getBlockAt(X, Y + 1, Z).getType());	// above target block open and safe
+		boolean safe =
+			// target block open and safe or is above maximum Y coordinate
+			(Y == world.getMaxHeight()
+			 || (safeOpenBlocks.contains(world.getBlockAt(X, Y, Z).getType())
+			     // above target block open and safe or is above maximum Y coordinate
+			     && (Y + 1 == world.getMaxHeight()
+				 || safeOpenBlocks.contains(world.getBlockAt(X, Y + 1, Z).getType()))));
 		if (!safe || flying)
 			return safe;
 
@@ -423,9 +428,9 @@ public class BorderData
 	// find closest safe Y position from the starting position
 	private double getSafeY(World world, int X, int Y, int Z, boolean flying)
 	{
-		// artificial height limit of 127 added for Nether worlds since CraftBukkit still incorrectly returns 255 for their max height, leading to players sent to the "roof" of the Nether
+		// artificial height limit of 127 added for Nether worlds since CraftBukkit still incorrectly returns 255 for their max height, leading to players sent to the "roof" of the Nether; we don't bother checking if Y = 126 or 127 are safe because they never will be unless there's a hole in the bedrock
 		final boolean isNether = world.getEnvironment() == World.Environment.NETHER;
-		int limTop = isNether ? 125 : world.getMaxHeight() - 2;
+		int limTop = isNether ? 125 : world.getMaxHeight();
 		// add 1 because getHighestBlockYAt() will give us the Y coordinate of a solid block, and we want the air block above it
 		final int highestBlockBoundary = Math.min(world.getHighestBlockYAt(X, Z) + 1, limTop);
 
@@ -449,12 +454,13 @@ public class BorderData
 		if (Y < limBot)
 			Y = limBot;
 
-		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to and including (hence the addition of 1) the highestBlockBoundary, unless player is flying
+		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to and including the highestBlockBoundary, unless player is flying
 		if (!isNether && !flying)
-			limTop = highestBlockBoundary + 1;
+			limTop = highestBlockBoundary;
 		// Expanding Y search method adapted from Acru's code in the Nether plugin
 
-		for(int y1 = Y, y2 = Y; (y1 > limBot) || (y2 < limTop); y1--, y2++){
+		// Note that we want to include limTop in the search - in the extreme case, world.getMaxHeight() should be included since the player can stand on top of the highest block
+		for(int y1 = Y, y2 = Y; (y1 > limBot) || (y2 <= limTop); y1--, y2++){
 			// Look below.
 			if(y1 > limBot)
 			{
@@ -463,7 +469,7 @@ public class BorderData
 			}
 
 			// Look above.
-			if(y2 < limTop && y2 != y1)
+			if(y2 <= limTop && y2 != y1)
 			{
 				if (isSafeSpot(world, X, y2, Z, flying))
 					return (double)y2;

--- a/src/main/java/com/wimbli/WorldBorder/BorderData.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderData.java
@@ -426,6 +426,7 @@ public class BorderData
 		// artificial height limit of 127 added for Nether worlds since CraftBukkit still incorrectly returns 255 for their max height, leading to players sent to the "roof" of the Nether
 		final boolean isNether = world.getEnvironment() == World.Environment.NETHER;
 		int limTop = isNether ? 125 : world.getMaxHeight() - 2;
+		// add 1 because getHighestBlockYAt() will give us the Y coordinate of a solid block, and we want the air block above it
 		final int highestBlockBoundary = Math.min(world.getHighestBlockYAt(X, Z) + 1, limTop);
 
 		// if Y is larger than the world can be and user can fly, return Y - Unless we are in the Nether, we might not want players on the roof
@@ -448,9 +449,9 @@ public class BorderData
 		if (Y < limBot)
 			Y = limBot;
 
-		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to the highestBlockBoundary, unless player is flying
+		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to and including (hence the addition of 1) the highestBlockBoundary, unless player is flying
 		if (!isNether && !flying)
-			limTop = highestBlockBoundary;
+			limTop = highestBlockBoundary + 1;
 		// Expanding Y search method adapted from Acru's code in the Nether plugin
 
 		for(int y1 = Y, y2 = Y; (y1 > limBot) || (y2 < limTop); y1--, y2++){

--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -489,10 +489,10 @@ public class Config
 			logConfig("Border-checking timed task stopped.");
 	}
 
-	public static void StopFillTask()
+	public static void StopFillTask(boolean SaveFill)
 	{
 		if (fillTask != null && fillTask.valid())
-			fillTask.cancel();
+			fillTask.cancel(SaveFill);
 	}
 
 	public static void StoreFillTask()
@@ -682,16 +682,15 @@ public class Config
 		if (storedFillTask != null)
 		{
 			String worldName = storedFillTask.getString("world");
-			int fillDistance = storedFillTask.getInt("fillDistance", 176);
-			int chunksPerRun = storedFillTask.getInt("chunksPerRun", 5);
-			int tickFrequency = storedFillTask.getInt("tickFrequency", 20);
+			int fillDistance = storedFillTask.getInt("fillDistance", 208);
+			int chunksPerRun = storedFillTask.getInt("chunksPerRun", 1);
+			int tickFrequency = storedFillTask.getInt("tickFrequency", 1);
 			int fillX = storedFillTask.getInt("x", 0);
 			int fillZ = storedFillTask.getInt("z", 0);
 			int fillLength = storedFillTask.getInt("length", 0);
 			int fillTotal = storedFillTask.getInt("total", 0);
 			boolean forceLoad = storedFillTask.getBoolean("forceLoad", false);
 			RestoreFillTask(worldName, fillDistance, chunksPerRun, tickFrequency, fillX, fillZ, fillLength, fillTotal, forceLoad);
-			save(false);
 		}
 
 		if (logIt)

--- a/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
@@ -48,7 +48,7 @@ public class WorldBorder extends JavaPlugin
 		DynMapFeatures.removeAllBorders();
 		Config.StopBorderTimer();
 		Config.StoreFillTask();
-		Config.StopFillTask();
+		Config.StopFillTask(true);
 	}
 
 	// for other plugins to hook into

--- a/src/main/java/com/wimbli/WorldBorder/WorldFillTask.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldFillTask.java
@@ -249,7 +249,8 @@ public class WorldFillTask implements Runnable
 			if (!chunkOnUnloadPreventionList(unload.x, unload.z))
 			{
 				world.setChunkForceLoaded(unload.x, unload.z, false);
-				world.unloadChunkRequest(unload.x, unload.z);
+				// this causes severe TPS loss by forcibly unloading chunks - instead, let server unload them naturally
+				//world.unloadChunkRequest(unload.x, unload.z);
 			}
 		}
 

--- a/src/main/java/com/wimbli/WorldBorder/WorldFillTask.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldFillTask.java
@@ -120,7 +120,8 @@ public class WorldFillTask implements Runnable
 				sendMessage("You must specify a world!");
 			else
 				sendMessage("World \"" + worldName + "\" not found!");
-			this.stop();
+			//In case world is not loaded yet, do not delete saved progress
+			this.stop(true);
 			return;
 		}
 
@@ -128,7 +129,7 @@ public class WorldFillTask implements Runnable
 		if (this.border == null)
 		{
 			sendMessage("No border found for world \"" + worldName + "\"!");
-			this.stop();
+			this.stop(false);
 			return;
 		}
 
@@ -136,7 +137,7 @@ public class WorldFillTask implements Runnable
 		worldData = WorldFileData.create(world, notifyPlayer);
 		if (worldData == null)
 		{
-			this.stop();
+			this.stop(false);
 			return;
 		}
 		
@@ -169,7 +170,7 @@ public class WorldFillTask implements Runnable
 
 	public void setTaskID(int ID)
 	{	
-		if (ID == -1) this.stop();
+		if (ID == -1) this.stop(false);
 		this.taskID = ID;
 	}
 
@@ -356,7 +357,9 @@ public class WorldFillTask implements Runnable
 				lastLegX = x;
 				lastLegZ = z;
 				lastLegTotal = reportTotal + reportNum;
-			} else {
+			} 
+			else 
+			{
 				refX = lastLegX;
 				refZ = lastLegZ;
 				refTotal = lastLegTotal;
@@ -422,18 +425,22 @@ public class WorldFillTask implements Runnable
 		world.save();
 		Bukkit.getServer().getPluginManager().callEvent(new WorldBorderFillFinishedEvent(world, reportTotal));
 		sendMessage("task successfully completed for world \"" + refWorld() + "\"!");
-		this.stop();
+		this.stop(false);
 	}
 
 	// for cancelling prematurely
-	public void cancel()
+	public void cancel(boolean SaveFill)
 	{
-		this.stop();
+		this.stop(SaveFill);
 	}
 
 	// we're done, whether finished or cancelled
-	private void stop()
+	private void stop(boolean SaveFill)
 	{
+		//If being called by onDisable(), don't delete fill progress
+		if (!SaveFill)
+			Config.UnStoreFillTask();
+		
 		if (server == null)
 			return;
 
@@ -482,8 +489,7 @@ public class WorldFillTask implements Runnable
 			Config.StoreFillTask();
 			reportProgress();
 		}
-		else
-			Config.UnStoreFillTask();
+
 	}
 	public boolean isPaused()
 	{
@@ -524,6 +530,8 @@ public class WorldFillTask implements Runnable
 			lastAutosave = lastReport;
 			sendMessage("Saving the world to disk, just to be on the safe side.");
 			world.save();
+			//In case of hard-crashes
+			Config.StoreFillTask();
 		}
 	}
 
@@ -559,6 +567,11 @@ public class WorldFillTask implements Runnable
 		this.length = length;
 		this.reportTotal = totalDone;
 		this.continueNotice = true;
+		//Prevents saving zeroes on first StoreFillTask after restoring
+		this.refX = x;
+		this.refZ = z;
+		this.refLength = length;
+		this.refTotal = totalDone;
 	}
 	public int refX()
 	{

--- a/src/main/java/com/wimbli/WorldBorder/cmd/CmdFill.java
+++ b/src/main/java/com/wimbli/WorldBorder/cmd/CmdFill.java
@@ -41,7 +41,7 @@ public class CmdFill extends WBCmd
 					return;
 				sender.sendMessage(C_HEAD + "Cancelling the world map generation task.");
 				fillDefaults();
-				Config.StopFillTask();
+				Config.StopFillTask(false);
 				return;
 			}
 			else if (check.equals("pause"))


### PR DESCRIPTION
Requesting chunk unloads during the fill task takes a tremendous hit on the server TPS, which leads to a really bad experience while players are online. It also slows down the fill process overall. By removing the chunk unload request, the server TPS will stay at a near 20 TPS due to the server now unloading the chunks naturally.

This leads to no noticeable downsides in my personal testing as well as many others personal testing over at the PaperMC discord. This will simply allow the server to handle unloading itself, which is seemingly much faster than a plugin requesting unloads.

I attempted to follow your comment style and commented out the line rather than deletion.

As always, feel free to do your own testing :)