### PR TITLE
Fixes related to teleport Y coordinates

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/BorderData.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderData.java
@@ -406,8 +406,13 @@ public class BorderData
 	// check if a particular spot consists of 2 breathable blocks over something relatively solid
 	private boolean isSafeSpot(World world, int X, int Y, int Z, boolean flying)
 	{
-		boolean safe = safeOpenBlocks.contains(world.getBlockAt(X, Y, Z).getType())		// target block open and safe
-					&& safeOpenBlocks.contains(world.getBlockAt(X, Y + 1, Z).getType());	// above target block open and safe
+		boolean safe =
+			// target block open and safe or is above maximum Y coordinate
+			(Y == world.getMaxHeight()
+			 || (safeOpenBlocks.contains(world.getBlockAt(X, Y, Z).getType())
+			     // above target block open and safe or is above maximum Y coordinate
+			     && (Y + 1 == world.getMaxHeight()
+				 || safeOpenBlocks.contains(world.getBlockAt(X, Y + 1, Z).getType()))));
 		if (!safe || flying)
 			return safe;
 
@@ -423,9 +428,9 @@ public class BorderData
 	// find closest safe Y position from the starting position
 	private double getSafeY(World world, int X, int Y, int Z, boolean flying)
 	{
-		// artificial height limit of 127 added for Nether worlds since CraftBukkit still incorrectly returns 255 for their max height, leading to players sent to the "roof" of the Nether
+		// artificial height limit of 127 added for Nether worlds since CraftBukkit still incorrectly returns 255 for their max height, leading to players sent to the "roof" of the Nether; we don't bother checking if Y = 126 or 127 are safe because they never will be unless there's a hole in the bedrock
 		final boolean isNether = world.getEnvironment() == World.Environment.NETHER;
-		int limTop = isNether ? 125 : world.getMaxHeight() - 2;
+		int limTop = isNether ? 125 : world.getMaxHeight();
 		// add 1 because getHighestBlockYAt() will give us the Y coordinate of a solid block, and we want the air block above it
 		final int highestBlockBoundary = Math.min(world.getHighestBlockYAt(X, Z) + 1, limTop);
 
@@ -449,12 +454,13 @@ public class BorderData
 		if (Y < limBot)
 			Y = limBot;
 
-		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to and including (hence the addition of 1) the highestBlockBoundary, unless player is flying
+		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to and including the highestBlockBoundary, unless player is flying
 		if (!isNether && !flying)
-			limTop = highestBlockBoundary + 1;
+			limTop = highestBlockBoundary;
 		// Expanding Y search method adapted from Acru's code in the Nether plugin
 
-		for(int y1 = Y, y2 = Y; (y1 > limBot) || (y2 < limTop); y1--, y2++){
+		// Note that we want to include limTop in the search - in the extreme case, world.getMaxHeight() should be included since the player can stand on top of the highest block
+		for(int y1 = Y, y2 = Y; (y1 > limBot) || (y2 <= limTop); y1--, y2++){
 			// Look below.
 			if(y1 > limBot)
 			{
@@ -463,7 +469,7 @@ public class BorderData
 			}
 
 			// Look above.
-			if(y2 < limTop && y2 != y1)
+			if(y2 <= limTop && y2 != y1)
 			{
 				if (isSafeSpot(world, X, y2, Z, flying))
 					return (double)y2;

--- a/src/main/java/com/wimbli/WorldBorder/BorderData.java
+++ b/src/main/java/com/wimbli/WorldBorder/BorderData.java
@@ -426,6 +426,7 @@ public class BorderData
 		// artificial height limit of 127 added for Nether worlds since CraftBukkit still incorrectly returns 255 for their max height, leading to players sent to the "roof" of the Nether
 		final boolean isNether = world.getEnvironment() == World.Environment.NETHER;
 		int limTop = isNether ? 125 : world.getMaxHeight() - 2;
+		// add 1 because getHighestBlockYAt() will give us the Y coordinate of a solid block, and we want the air block above it
 		final int highestBlockBoundary = Math.min(world.getHighestBlockYAt(X, Z) + 1, limTop);
 
 		// if Y is larger than the world can be and user can fly, return Y - Unless we are in the Nether, we might not want players on the roof
@@ -448,9 +449,9 @@ public class BorderData
 		if (Y < limBot)
 			Y = limBot;
 
-		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to the highestBlockBoundary, unless player is flying
+		// for non Nether worlds we don't need to check upwards to the world-limit, it is enough to check up to and including (hence the addition of 1) the highestBlockBoundary, unless player is flying
 		if (!isNether && !flying)
-			limTop = highestBlockBoundary;
+			limTop = highestBlockBoundary + 1;
 		// Expanding Y search method adapted from Acru's code in the Nether plugin
 
 		for(int y1 = Y, y2 = Y; (y1 > limBot) || (y2 < limTop); y1--, y2++){


### PR DESCRIPTION
This PR includes two commits for separate issues related to the selection of the Y coordinate that the player is teleported to.  Following are some brief descriptions of the commits, see the commit messages for more details.

The first commit probably fixes two reported issues, at least partially.  There was a problem with teleporting to be on top of the highest block if it wasn't at the player's current Y coordinate which would result in the player being teleported to spawn instead if there were no air gaps.  I think this fixes issue #178 and probably issue #115 too.  On its own this is a trivial commit.

The second commit isn't associated with any reported issues, but while working on the above I noticed that the teleporting code wouldn't deal well with blocks at (assuming the standard world height of 256) Y = 254 or 255 because it insisted on checking if the blocks into which the player would be teleported (Y and Y + 1) were breathable.  My fix assumes that the void above the top of the world is breathable.  This certainly seems to be the case in vanilla Minecraft.

Since the second commit is more complicated and doesn't address an existing issue, I've kept it as a separate commit even though it touches the same areas of the code as the first commit and in fact replaces some of the changes made by that commit.  This way, if you don't want the change from the second commit or just don't want to have to review it, just the first commit can be pulled.

I tested the first commit by verifying it made the problem I saw as described in issue #178 go away, and tested the second by building a sort of staircase ascending to Y = 255 and verifying that I was teleported up it all the way to the top (in a situation where the teleport moved me not only backwards but also sideways due to a circular border).